### PR TITLE
[Fixes] Fix forgot password redirect url

### DIFF
--- a/src/Components/Auth/ForgotPassword.jsx
+++ b/src/Components/Auth/ForgotPassword.jsx
@@ -53,7 +53,7 @@ class ForgotPassword extends Component {
 
       const { email } = this.state;
 
-      const url = "auth/forgot-password";
+      const url = "/auth/forgot-password";
 
       requestAgent.post(url)
         .set('Content-Type', 'application/json')


### PR DESCRIPTION
**What does this PR do?**
Fixes Forgot password feature

**PR description**
Forgot password API route was all wrong therefore the request sent to api server to reset password could not reach the API endpoint

**How should this PR be tested**
Navigate to `auth/forgot-password` and try to reset password